### PR TITLE
Add placeholder Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: required
+
+services:
+  - docker


### PR DESCRIPTION
This is a placeholder Travis config file that will allow enabling Travis CI builds (#4).  It contains the initial lines from the example at https://docs.travis-ci.com/user/docker/