### PR TITLE
Test running SCINGE inside Octave Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ sudo: required
 
 services:
   - docker
+  
+before_install:
+  - docker pull openmicroscopy/octave
+  - docker ps -a
+
+script:
+  - docker run -v $(pwd):/SCINGE openmicroscopy/octave /SCINGE/SCINGE_Example.m


### PR DESCRIPTION
This is an attempt to run SCINGE on Travis CI inside an Octave Docker container (#4).  It initially uses https://hub.docker.com/r/openmicroscopy/octave and examples from https://github.com/openmicroscopy/octave-docker.