### PR TITLE
Modernize Dockerfile and GitHub actions tests

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -35,7 +35,8 @@ jobs:
         context: .
         file: docker/Dockerfile
         tags: agitter/singe:tmp
-        cache-from: type=registry,ref=agitter/singe:tmp
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         load: true
         push: false
     # Only push when running on the master branch

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -3,6 +3,7 @@ name: Install test SINGE
 on:
   push:
   pull_request:
+  # Allow manual runs from the Actions tab while iterating on this update
   workflow_dispatch:
 
 jobs:
@@ -85,6 +86,9 @@ jobs:
         # the Anaconda Terms of Service, so environment.yml resolves without a
         # ToS-acceptance step and needs no channel changes.
         miniforge-version: latest
+        # Drop the implicitly-added 'defaults' channel so the solve is purely
+        # conda-forge (silences the setup-miniconda warning).
+        conda-remove-defaults: true
     - name: Cache MATLAB runtime installer
       id: cache-installer
       uses: actions/cache@v4
@@ -103,7 +107,10 @@ jobs:
         sudo ./MATLAB_Runtime_R2020a_Update_2_maci64/InstallForMacOSX.app/Contents/MacOS/InstallForMacOSX -mode silent -agreeToLicense yes
         MATLAB_RUNTIME_PATH=/Applications/MATLAB/MATLAB_Runtime/v98
         echo "MATLAB_RUNTIME_PATH=$MATLAB_RUNTIME_PATH" >> $GITHUB_ENV
-        echo "DYLD_LIBRARY_PATH=$MATLAB_RUNTIME_PATH/runtime/maci64:$MATLAB_RUNTIME_PATH/sys/os/maci64:$MATLAB_RUNTIME_PATH/bin/maci64" >> $GITHUB_ENV
+        # Do not export DYLD_LIBRARY_PATH globally. It leaks into every later step
+        # and makes conda's Python load MATLAB's bundled libcurl/libexpat (missing
+        # symbols -> conda entry-point errors). The MCR wrapper (run_SINGE_*_mac.sh)
+        # sets DYLD_LIBRARY_PATH itself from MATLAB_RUNTIME_PATH for each SINGE run.
         echo "$MATLAB_RUNTIME_PATH/bin/maci64" >> $GITHUB_PATH
     - name: Download SINGE
       run: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -36,7 +36,7 @@ jobs:
         file: docker/Dockerfile
         tags: agitter/singe:tmp
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=min
         load: true
         push: false
     # Only push when running on the master branch

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,6 +1,9 @@
 name: Install test SINGE
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   # Builds and tests the SINGE Docker image, tests SINGE in a Docker container
@@ -9,25 +12,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      # Pull from Docker Hub to use the cache
-      # https://medium.com/mobileforgood/coding-tips-patterns-for-continuous-integration-with-docker-on-travis-ci-9cedb8348a62
-      # https://github.com/docker/build-push-action/issues/7
-    - name: Pull Docker image
-      run: docker pull agitter/singe:tmp
-    - name: Build Docker image
-      uses: docker/build-push-action@v1
+      uses: actions/checkout@v4
+    # Buildx is required by docker/build-push-action v2+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    # Credentials are only needed for the push, which happens on master
+    - name: Log in to Docker Hub
+      if: github.ref == 'refs/heads/master'
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        path: .
-        dockerfile: docker/Dockerfile
-        repository: agitter/singe
-        tags: tmp
-        cache_froms: agitter/singe:tmp
-        add_git_labels: true
-        # Only push when running on the master branch
-        push: ${{ github.ref == 'refs/heads/master' }}
+    # Replaces the deprecated docker/build-push-action@v1 and the manual
+    # "docker pull" cache-warming step. cache-from reuses the layers of the
+    # previously pushed agitter/singe:tmp image, matching the old cache_froms
+    # behavior. load: true makes the built image available to the local Docker
+    # daemon so the test step below can "docker run" it.
+    - name: Build Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        tags: agitter/singe:tmp
+        cache-from: type=registry,ref=agitter/singe:tmp
+        load: true
+        push: false
+    # Only push when running on the master branch
+    - name: Push Docker image
+      if: github.ref == 'refs/heads/master'
+      run: docker push agitter/singe:tmp
     - name: Test SINGE
       run: |
         # Store the md5sums of the tracked source files before running tests in the Docker image
@@ -52,23 +65,29 @@ jobs:
   # Installs MATLAB runtime R2020a and tests compiled SINGE for macOS on test data
   macos:
     name: Install test macOS
-    # See available macOS software https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
-    runs-on: macos-latest
+    # macos-latest is now arm64; the maci64 runtime and Intel-compiled SINGE
+    # binaries require an x86_64 runner. macos-15-intel is available until ~Aug 2027.
+    # See available macOS software https://github.com/actions/runner-images/tree/main/images/macos
+    runs-on: macos-15-intel
     env:
       SINGE_VERSION: v0.5.1
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install conda environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v4
       with:
         activate-environment: singe-test
         environment-file: tests/environment.yml
-        auto-activate-base: false
-        miniconda-version: 'latest'
+        # Renamed from auto-activate-base in setup-miniconda v4
+        auto-activate: false
+        # Miniforge defaults to the conda-forge channel and is not governed by
+        # the Anaconda Terms of Service, so environment.yml resolves without a
+        # ToS-acceptance step and needs no channel changes.
+        miniforge-version: latest
     - name: Cache MATLAB runtime installer
       id: cache-installer
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: installer
         key: ${{ runner.os }}-matlab-R2020a-installer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,8 @@
 FROM amarburg/matlab-runtime:R2018a
 
 RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
-RUN apt-get update && \
-    apt-get -y install libxt6 bzip2 && \
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get -y --allow-unauthenticated install libxt6 bzip2 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Miniconda3 following https://hub.docker.com/r/continuumio/miniconda3/dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,20 +6,18 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && \
     apt-get -y --allow-unauthenticated install libxt6 bzip2 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Miniconda3 following https://hub.docker.com/r/continuumio/miniconda3/dockerfile
-# Python is only needed for testing SINGE and could be removed from the base
-# to reduce the image size
-ENV PATH /opt/conda/bin:$PATH
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh --no-check-certificate -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh && \
-    /opt/conda/bin/conda clean --all && \
+# Install Miniforge (conda-forge distribution of conda)
+ENV PATH=/opt/conda/bin:$PATH
+RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-Linux-x86_64.sh -O ~/miniforge.sh && \
+    /bin/bash ~/miniforge.sh -b -p /opt/conda && \
+    rm ~/miniforge.sh && \
+    /opt/conda/bin/conda clean --all --yes && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
     conda init bash
 
-ENV SINGE_ROOT /usr/local/SINGE
+ENV SINGE_ROOT=/usr/local/SINGE
 WORKDIR /usr/local/SINGE
 ENTRYPOINT ["/usr/local/SINGE/SINGE.sh", "/usr/local/MATLAB/MATLAB_Runtime/v94"]
 
@@ -33,7 +31,7 @@ COPY run_SINGE_GLG_Test.sh .
 COPY run_SINGE_Aggregate.sh .
 COPY tests/run_SINGE_Test.sh tests/
 
-ENV SINGE_RUNNING_IN_DOCKER 1
+ENV SINGE_RUNNING_IN_DOCKER=1
 
 # Download the compiled SINGE executables from the stable release
 # md5sum of v0.5.1 SINGE_GLG_Test is 95bc486778c3111533944480a2be3b74

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -1,10 +1,10 @@
 name: singe-test
 dependencies:
-  - h5py=2.10.0
-  - numpy=1.16.3
-  - pip=19.1.1
-  - python=3.7.11
-  - scipy=1.2.1
+  - h5py=2.10
+  - numpy=1.16
+  - pip=19.1
+  - python=3.7
+  - scipy=1.2
   - pip:
     - csvdiff==0.3.3
     - hdf5storage==0.1.15


### PR DESCRIPTION
Switch to modern GitHub actions versions, miniforge for conda, and newer Intel-based macOS runner. Workaround old end-of-life Docker base image and env var syntax. Relax conda environment pins.

Deferring replacing the Docker base image and migrating to matlab-actions.